### PR TITLE
Enhance check for assignment by rather checking if assigned variable is used in assignment block

### DIFF
--- a/RuleDocumentation/PossibleIncorrectUsageOfComparisonOperator.md
+++ b/RuleDocumentation/PossibleIncorrectUsageOfComparisonOperator.md
@@ -1,7 +1,43 @@
 # PossibleIncorrectUsageOfComparisonOperator
 
-**Severity Level: Information**
+** Severity Level: Warning **
 
 ## Description
 
 In many programming languages, the comparison operator for greater is `>` but `PowerShell` uses `-gt` for it and `-ge` for `>=`. Similarly the equality operator is denoted as `==` or `=` in many programming languages, but `PowerShell` uses `-eq`. Since using as the FileRedirection operator `>` or the assignment operator are rarely needed inside if statements, this rule wants to call out this case because it was probably unintentional.
+
+The rule looks for usages of `==`, `=` and `>` operators inside if statements and for the case of assignments, it will only warn if the variable is not being used at all in the statement block to avoid false positives because assigning a variable inside an if statement is an elegant way of getting an object and performing an implicit null check on it in one line.
+
+## Example
+
+### Wrong
+
+``` PowerShell
+if ($superman > $batman)
+{
+
+}
+```
+
+``` PowerShell
+if ($superman == $batman)
+{
+
+}
+```
+
+``` PowerShell
+if ($superman = $batman)
+{
+    # Not using the assigned variable is an indicator that assignment was either by accident or unintentional
+}
+```
+
+### Correct
+
+``` PowerShell
+if ($superman = Get-Superman)
+{
+    Save-World $superman
+}
+```

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             if (leftVariableExpressionAstOfAssignment != null)
                             {
                                 var statementBlockOfIfStatenent = clause.Item2;
-                                var variableExpressionAstsInStatementBlockOfIfStatement = statementBlockOfIfStatenent.FindAll(testAst => testAst is VariableExpressionAst, searchNestedScriptBlocks: true);
+                                var variableExpressionAstsInStatementBlockOfIfStatement = statementBlockOfIfStatenent.FindAll(testAst =>
+                                                                                                testAst is VariableExpressionAst, searchNestedScriptBlocks: true);
                                 if (variableExpressionAstsInStatementBlockOfIfStatement == null) // no variable uages at all
                                 {
                                     yield return PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError(assignmentStatementAst.ErrorPosition, fileName);
@@ -67,7 +68,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 else
                                 {
                                     var variableOnLHSIsBeingUsed = variableExpressionAstsInStatementBlockOfIfStatement.Where(x => x is VariableExpressionAst)
-                                                                .Any(x => ((VariableExpressionAst)x).VariablePath.UserPath.Equals(leftVariableExpressionAstOfAssignment.VariablePath.UserPath, StringComparison.OrdinalIgnoreCase));
+                                        .Any(x => ((VariableExpressionAst)x).VariablePath.UserPath.Equals(
+                                            leftVariableExpressionAstOfAssignment.VariablePath.UserPath, StringComparison.OrdinalIgnoreCase));
 
                                     if (!variableOnLHSIsBeingUsed)
                                     {

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 var statementBlockOfIfStatenent = clause.Item2;
                                 var variableExpressionAstsInStatementBlockOfIfStatement = statementBlockOfIfStatenent.FindAll(testAst =>
                                                                                                 testAst is VariableExpressionAst, searchNestedScriptBlocks: true);
-                                if (variableExpressionAstsInStatementBlockOfIfStatement == null) // no variable uages at all
+                                if (variableExpressionAstsInStatementBlockOfIfStatement == null) // no variable usages at all
                                 {
                                     yield return PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError(assignmentStatementAst.ErrorPosition, fileName);
                                 }

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -43,43 +43,52 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 foreach (var clause in ifStatementAst.Clauses)
                 {
-                    var assignmentStatementAst = clause.Item1.Find(testAst => testAst is AssignmentStatementAst, searchNestedScriptBlocks: false) as AssignmentStatementAst;
-                    if (assignmentStatementAst != null)
+                    var ifStatementCondition = clause.Item1;
+                    var assignmentStatementAst = ifStatementCondition.Find(testAst => testAst is AssignmentStatementAst, searchNestedScriptBlocks: false) as AssignmentStatementAst;
+                    if (assignmentStatementAst == null)
                     {
-                        // Check if someone used '==', which can easily happen when the person is used to coding a lot in C#.
-                        // In most cases, this will be a runtime error because PowerShell will look for a cmdlet name starting with '=', which is technically possible to define
-                        if (assignmentStatementAst.Right.Extent.Text.StartsWith("="))
+                        continue;
+                    }
+                    // Check if someone used '==', which can easily happen when the person is used to coding a lot in C#.
+                    // In most cases, this will be a runtime error because PowerShell will look for a cmdlet name starting with '=', which is technically possible to define
+                    if (assignmentStatementAst.Right.Extent.Text.StartsWith("="))
+                    {
+                        yield return new DiagnosticRecord(
+                            Strings.PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError, assignmentStatementAst.ErrorPosition,
+                            GetName(), DiagnosticSeverity.Warning, fileName);
+                    }
+                    else
+                    {
+                        var leftVariableExpressionAstOfAssignment = assignmentStatementAst.Left as VariableExpressionAst;
+                        if (leftVariableExpressionAstOfAssignment == null)
+                        {
+                            continue;
+                        }
+                        var statementBlockOfIfStatenent = clause.Item2;
+                        var variableExpressionAstsInStatementBlockOfIfStatement = statementBlockOfIfStatenent.FindAll(testAst => testAst is VariableExpressionAst, searchNestedScriptBlocks: true);
+                        if (variableExpressionAstsInStatementBlockOfIfStatement == null) // no variable uages
                         {
                             yield return new DiagnosticRecord(
                                 Strings.PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError, assignmentStatementAst.ErrorPosition,
-                                GetName(), DiagnosticSeverity.Warning, fileName);
+                                GetName(), DiagnosticSeverity.Information, fileName);
                         }
                         else
                         {
-                            if (assignmentStatementAst.Left is VariableExpressionAst)
+                            var variableOnLHSIsBeingUsed = variableExpressionAstsInStatementBlockOfIfStatement.Where(x => x is VariableExpressionAst)
+                                                        .Any(x => ((VariableExpressionAst)x).VariablePath.UserPath.Equals(leftVariableExpressionAstOfAssignment.VariablePath.UserPath, StringComparison.OrdinalIgnoreCase));
+
+                            if (variableOnLHSIsBeingUsed)
                             {
-                                var vast = assignmentStatementAst.Left as VariableExpressionAst;
-                                var veAsts = clause.Item2.FindAll(testAst => testAst is VariableExpressionAst, searchNestedScriptBlocks: true);
-                                if (veAsts == null)
-                                {
-                                    yield return new DiagnosticRecord(
-                                       Strings.PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError, assignmentStatementAst.ErrorPosition,
-                                       GetName(), DiagnosticSeverity.Information, fileName);
-                                }
-                                else
-                                {
-                                    // Check if LHS is being used
-                                    var variableIsBeingUsed = veAsts.Where(x => x is VariableExpressionAst).Any(x =>( (VariableExpressionAst)x).VariablePath.UserPath == vast.VariablePath.UserPath);
-                                    // If the right hand side contains a CommandAst at some point, then we do not want to warn
-                                    // because this could be intentional in cases like 'if ($a = Get-ChildItem){ }'
-                                    var commandAst = assignmentStatementAst.Right.Find(testAst => testAst is CommandAst, searchNestedScriptBlocks: true) as CommandExpressionAst;
-                                    if (commandAst == null && !variableIsBeingUsed)
-                                    {
-                                        yield return new DiagnosticRecord(
-                                            Strings.PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError, assignmentStatementAst.ErrorPosition,
-                                            GetName(), DiagnosticSeverity.Information, fileName);
-                                    }
-                                }
+                                continue;
+                            }
+                            // If the right hand side contains a CommandAst at some point, then we do not want to warn
+                            // because this could be intentional in cases like 'if ($a = Get-ChildItem){ }'
+                            var commandAst = assignmentStatementAst.Right.Find(testAst => testAst is CommandAst, searchNestedScriptBlocks: true) as CommandExpressionAst;
+                            if (commandAst == null && !variableOnLHSIsBeingUsed)
+                            {
+                                yield return new DiagnosticRecord(
+                                    Strings.PossibleIncorrectUsageOfComparisonOperatorAssignmentOperatorError, assignmentStatementAst.ErrorPosition,
+                                    GetName(), DiagnosticSeverity.Information, fileName);
                             }
                         }
                     }

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                     {
                                         // If the right hand side contains a CommandAst at some point, then we do not want to warn
                                         // because this could be intentional in cases like 'if ($a = Get-ChildItem){ }'
-                                        var commandAst = assignmentStatementAst.Right.Find(testAst => testAst is CommandAst, searchNestedScriptBlocks: true) as CommandExpressionAst;
+                                        var commandAst = assignmentStatementAst.Right.Find(testAst => testAst is CommandAst, searchNestedScriptBlocks: true) as CommandAst;
                                         if (commandAst == null)
                                         {
                                             yield return new DiagnosticRecord(

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -159,7 +159,7 @@ Describe "TestSeverity" {
 
     It "filters rules based on multiple severity inputs"{
         $rules = Get-ScriptAnalyzerRule -Severity Error,Information
-        $rules.Count | Should be 15
+        $rules.Count | Should be 14
     }
 
         It "takes lower case inputs" {

--- a/Tests/Rules/PossibleIncorrectUsageOfComparisonOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfComparisonOperator.tests.ps1
@@ -65,6 +65,11 @@ Describe "PossibleIncorrectUsageOfComparisonOperator" {
             $warnings.Count | Should Be 0
         }
 
+        It "returns no violations when the variable assigned on the LHS is used" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = $b){ $a.DoSomething() }' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 0
+        }
+
         It "returns no violations when there is an evaluation on the RHS" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0

--- a/Tests/Rules/PossibleIncorrectUsageOfComparisonOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfComparisonOperator.tests.ps1
@@ -61,27 +61,22 @@ Describe "PossibleIncorrectUsageOfComparisonOperator" {
 
     Context "When there are no violations" {
         It "returns no violations when there is no equality operator" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){$a=$b}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){ }' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
 
-        It "returns no violations when the variable assigned on the LHS is used" {
+        It "returns no violations when using assignment but the assigned variable on the LHS is used" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = $b){ $a.DoSomething() }' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
 
-        It "returns no violations when there is an evaluation on the RHS" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){}' | Where-Object {$_.RuleName -eq $ruleName}
+        It "returns no violations when there is an evaluation on the RHS but the assigned variable on the LHS is used" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){ Get-Something $a }' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
 
-        It "returns no violations when there is an evaluation on the RHS wrapped in an expression" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem)){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 0
-        }
-
-        It "returns no violations when there is an evaluation on the RHS wrapped in an expression and also includes a variable" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem $b)){}' | Where-Object {$_.RuleName -eq $ruleName}
+        It "returns no violations when there is an evaluation on the RHS wrapped in an expression but the assigned variable on the LHS is used" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem)){ $b = $a }' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
     }


### PR DESCRIPTION
to avoid false positives for assignments: check if variable on LHS is used in statement block
update documentation and change level to warning since we are now much more certain that a violation. is happening